### PR TITLE
Added check for response for fatal errors creating a websocket connection

### DIFF
--- a/deepgram/transcriptions.go
+++ b/deepgram/transcriptions.go
@@ -56,7 +56,11 @@ func (dg *Client) LiveTranscription(options LiveTranscriptionOptions) (*websocke
 	c, resp, err := websocket.DefaultDialer.Dial(u.String(), header)
 
 	if err != nil {
-		log.Printf("handshake failed with status %s", resp.Status)
+		if resp != nil {
+			log.Printf("handshake failed with status %s", resp.Status)
+		} else {
+			log.Printf("handshake failed with no response")
+		}
 		log.Fatal("dial:", err)
 	}
 	return c, resp, nil


### PR DESCRIPTION
This MR includes:
- Modified logging checks for websocket error messages

Description

It's not guaranteed the websocket dial function returns a response which means we hit a nil pointer error logging below. To avoid we need to check for a nil response before printing and move on to logging the fatal error.

Raw Error
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x71d479]
goroutine 207 [running]:
github.com/alexanderyoung/deepgram-go-sdk/deepgram.(*Client).LiveTranscription(_, {0x1, {0x0, 0x0}, 0x0, 0x0, 0x1, {0x0, 0x0}, 0x0, ...})
	/root/go/pkg/mod/github.com/alexanderyoung/deepgram-go-sdk@v0.0.1/deepgram/transcriptions.go:59 +0x459
```

