### PR TITLE
Added retry logic to retrieving websocket client

### DIFF
--- a/deepgram/client.go
+++ b/deepgram/client.go
@@ -1,0 +1,44 @@
+package deepgram
+
+import (
+	"errors"
+	"log"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// GetClient creates a new websocket client connection
+func GetClient(header http.Header, u url.URL) (*websocket.Conn, *http.Response, error) {
+	c, resp, err := websocket.DefaultDialer.Dial(u.String(), header)
+	if err != nil {
+		log.Printf("error creating a new client connection: %s", err.Error())
+		if resp != nil {
+			log.Printf("handshake failed with status %s", resp.Status)
+		} else {
+			log.Printf("handshake failed with no response")
+		}
+		return retry(header, u)
+	}
+	return c, resp, nil
+}
+
+// retry creates a new websocket client connection with a timed retry logic
+func retry(header http.Header, u url.URL) (*websocket.Conn, *http.Response, error) {
+	log.Printf("Attemping to open a new client connection with a retry...")
+	retryCount := 0
+	for retryCount < 4 {
+		// Every 5 seconds the transcriber will attempt to create a new websocket
+		time.Sleep(time.Second * 5)
+		c, res, err := websocket.DefaultDialer.Dial(u.String(), header)
+		if err != nil {
+			log.Printf("Failed to to open an new client connection, retrying in 5 seconds...")
+			retryCount++
+		} else {
+			return c, res, err
+		}
+	}
+	return nil, nil, errors.New("failed to open a new client connection after 3 retries")
+}

--- a/deepgram/transcriptions.go
+++ b/deepgram/transcriptions.go
@@ -52,16 +52,9 @@ func (dg *Client) LiveTranscription(options LiveTranscriptionOptions) (*websocke
 		"Authorization": []string{"token " + dg.ApiKey},
 		"X-DG-Agent":    []string{dgAgent},
 	}
-
-	c, resp, err := websocket.DefaultDialer.Dial(u.String(), header)
-
+	c, resp, err := GetClient(header, u)
 	if err != nil {
-		if resp != nil {
-			log.Printf("handshake failed with status %s", resp.Status)
-		} else {
-			log.Printf("handshake failed with no response")
-		}
-		log.Fatal("dial:", err)
+		log.Fatal("unable to create websocket client", err)
 	}
 	return c, resp, nil
 }


### PR DESCRIPTION
This MR includes:
- Improved some logging around a potential error with retrieving websocket client
- Added retry logic for creation of client on initial failure before failing

